### PR TITLE
C4 architecture stream: event log and Mermaid projections

### DIFF
--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,0 +1,3 @@
+# C4 Architecture
+
+_Not finalized yet._

--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,3 +1,62 @@
 # C4 Architecture
 
-_Not finalized yet._
+Projections from `docs/c4-events.ndjson` (frozen through pass 4).
+
+## L1 — System context
+
+```mermaid
+flowchart TB
+  actor_integrator["actor:integrator<br/>Connector integrator"]
+  actor_maintainer["actor:maintainer<br/>Repository maintainer"]
+  ext_github["ext:github<br/>GitHub"]
+  ext_npm["ext:npm_ecosystem<br/>Node/npm/Yarn ecosystem"]
+  sys_decreen["sys:decreen_connectors<br/>Decreen Connectors"]
+  actor_integrator -->|"edge:integrator_github<br/>obtain repository"| ext_github
+  actor_maintainer -->|"edge:maintainer_github<br/>git operations"| ext_github
+  actor_maintainer -->|"edge:maintainer_workspace<br/>edit working tree"| sys_decreen
+  sys_decreen -->|"edge:workspace_remote<br/>git remote sync"| ext_github
+```
+
+## L2 — Containers
+
+```mermaid
+flowchart TB
+  subgraph sys_decreen["sys:decreen_connectors"]
+    c_workspace["container:local_repo_workspace<br/>Local repository workspace"]
+  end
+  actor_maintainer["actor:maintainer<br/>Repository maintainer"]
+  ext_github["ext:github<br/>GitHub"]
+  actor_maintainer -->|"edge:maintainer_workspace<br/>edit working tree"| c_workspace
+  c_workspace -->|"edge:workspace_remote<br/>git remote sync"| ext_github
+```
+
+## L3 — `container:local_repo_workspace`
+
+```mermaid
+flowchart TB
+  %% SCOPE: urn:c4:container:container:local_repo_workspace
+  subgraph c_workspace["container:local_repo_workspace"]
+    direction TB
+    comp_git["component:git_remote_integration<br/>Git remote integration"]
+    comp_ignore["component:repo_ignore_policy<br/>Repository ignore policy"]
+  end
+  ext_github["ext:github<br/>GitHub"]
+  ext_npm["ext:npm_ecosystem<br/>Node/npm/Yarn ecosystem"]
+  comp_git -->|"edge:git_remote_github<br/>origin remote"| ext_github
+  comp_ignore -->|"edge:ignore_npm_paths<br/>excludes node_modules and package caches"| ext_npm
+```
+
+### L3 kind annotations (from stream)
+
+| ID | KIND (primary) |
+|----|----------------|
+| `component:git_remote_integration` | `integration` |
+| `component:repo_ignore_policy` | `boundary` |
+
+## Full containment map
+
+| Parent | Child |
+|--------|--------|
+| `sys:decreen_connectors` | `container:local_repo_workspace` |
+| `container:local_repo_workspace` | `component:git_remote_integration` |
+| `container:local_repo_workspace` | `component:repo_ignore_policy` |

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,0 +1,1 @@
+{"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -16,3 +16,9 @@
 {"seq":16,"pass":2,"event":"add_edge","payload":{"id":"edge:workspace_remote","from":"container:local_repo_workspace","to":"ext:github","label":"git remote sync"}}
 {"seq":17,"pass":2,"event":"add_edge","payload":{"id":"edge:integrator_github","from":"actor:integrator","to":"ext:github","label":"obtain repository"}}
 {"seq":18,"pass":2,"event":"freeze_pass","payload":{"pass":2}}
+{"seq":19,"pass":3,"event":"add_component","payload":{"id":"component:git_remote_integration","container_id":"container:local_repo_workspace","label":"Git remote integration","kinds":["integration","routing"]}}
+{"seq":20,"pass":3,"event":"add_component","payload":{"id":"component:repo_ignore_policy","container_id":"container:local_repo_workspace","label":"Repository ignore policy","kinds":["boundary","state"]}}
+{"seq":21,"pass":3,"event":"exclude_candidate","payload":{"id":"exclude:l3_second_container","reason":"Only one L2 container present; Pass 3 selection applies to container:local_repo_workspace only"}}
+{"seq":22,"pass":3,"event":"add_edge","payload":{"id":"edge:git_remote_github","from":"component:git_remote_integration","to":"ext:github","label":"origin remote"}}
+{"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:ignore_npm_paths","from":"component:repo_ignore_policy","to":"ext:npm_ecosystem","label":"excludes node_modules and package caches"}}
+{"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,1 +1,9 @@
 {"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}
+{"seq":2,"pass":1,"event":"add_actor","payload":{"id":"actor:integrator","label":"Connector integrator"}}
+{"seq":3,"pass":1,"event":"add_actor","payload":{"id":"actor:maintainer","label":"Repository maintainer"}}
+{"seq":4,"pass":1,"event":"add_external","payload":{"id":"ext:github","label":"GitHub"}}
+{"seq":5,"pass":1,"event":"add_external","payload":{"id":"ext:npm_ecosystem","label":"Node/npm/Yarn ecosystem"}}
+{"seq":6,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1-runtime","label":"Pass 1 runtime inventory","members":["actor:integrator","actor:maintainer","ext:github","ext:npm_ecosystem"]}}
+{"seq":7,"pass":1,"event":"exclude_candidate","payload":{"id":"exclude:deployable_runtime","reason":"No application source, package manifest, Dockerfile, or CI workflow files present in workspace tree"}}
+{"seq":8,"pass":1,"event":"add_edge","payload":{"id":"edge:maintainer_github","from":"actor:maintainer","to":"ext:github","label":"git operations"}}
+{"seq":9,"pass":1,"event":"freeze_pass","payload":{"pass":1}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -22,3 +22,4 @@
 {"seq":22,"pass":3,"event":"add_edge","payload":{"id":"edge:git_remote_github","from":"component:git_remote_integration","to":"ext:github","label":"origin remote"}}
 {"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:ignore_npm_paths","from":"component:repo_ignore_policy","to":"ext:npm_ecosystem","label":"excludes node_modules and package caches"}}
 {"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3}}
+{"seq":25,"pass":4,"event":"freeze_pass","payload":{"pass":4}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -7,3 +7,12 @@
 {"seq":7,"pass":1,"event":"exclude_candidate","payload":{"id":"exclude:deployable_runtime","reason":"No application source, package manifest, Dockerfile, or CI workflow files present in workspace tree"}}
 {"seq":8,"pass":1,"event":"add_edge","payload":{"id":"edge:maintainer_github","from":"actor:maintainer","to":"ext:github","label":"git operations"}}
 {"seq":9,"pass":1,"event":"freeze_pass","payload":{"pass":1}}
+{"seq":10,"pass":2,"event":"set_system_boundary","payload":{"id":"sys:decreen_connectors","label":"Decreen Connectors"}}
+{"seq":11,"pass":2,"event":"add_container","payload":{"id":"container:local_repo_workspace","label":"Local repository workspace"}}
+{"seq":12,"pass":2,"event":"exclude_candidate","payload":{"id":"exclude:ci_runtime","reason":".github/workflows and CI configs absent from workspace"}}
+{"seq":13,"pass":2,"event":"exclude_candidate","payload":{"id":"exclude:container_image","reason":"No Dockerfile or container build files in workspace"}}
+{"seq":14,"pass":2,"event":"exclude_candidate","payload":{"id":"exclude:npm_package_app","reason":"No package.json or lockfiles present as application entry"}}
+{"seq":15,"pass":2,"event":"add_edge","payload":{"id":"edge:maintainer_workspace","from":"actor:maintainer","to":"container:local_repo_workspace","label":"edit working tree"}}
+{"seq":16,"pass":2,"event":"add_edge","payload":{"id":"edge:workspace_remote","from":"container:local_repo_workspace","to":"ext:github","label":"git remote sync"}}
+{"seq":17,"pass":2,"event":"add_edge","payload":{"id":"edge:integrator_github","from":"actor:integrator","to":"ext:github","label":"obtain repository"}}
+{"seq":18,"pass":2,"event":"freeze_pass","payload":{"pass":2}}

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,10 +1,16 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart TD
+flowchart TB
+  subgraph sys_decreen["sys:decreen_connectors<br/>Decreen Connectors"]
+    c_workspace["container:local_repo_workspace<br/>Local repository workspace"]
+  end
   actor_integrator["actor:integrator<br/>Connector integrator"]
   actor_maintainer["actor:maintainer<br/>Repository maintainer"]
   ext_github["ext:github<br/>GitHub"]
   ext_npm["ext:npm_ecosystem<br/>Node/npm/Yarn ecosystem"]
   actor_maintainer -->|"edge:maintainer_github<br/>git operations"| ext_github
+  actor_maintainer -->|"edge:maintainer_workspace<br/>edit working tree"| c_workspace
+  c_workspace -->|"edge:workspace_remote<br/>git remote sync"| ext_github
+  actor_integrator -->|"edge:integrator_github<br/>obtain repository"| ext_github
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,0 +1,6 @@
+# Live C4 Preview
+
+```mermaid
+flowchart TD
+  boot["C4 generation started"]
+```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -3,7 +3,10 @@
 ```mermaid
 flowchart TB
   subgraph sys_decreen["sys:decreen_connectors<br/>Decreen Connectors"]
-    c_workspace["container:local_repo_workspace<br/>Local repository workspace"]
+    subgraph c_workspace["container:local_repo_workspace"]
+      comp_git["component:git_remote_integration<br/>Git remote integration"]
+      comp_ignore["component:repo_ignore_policy<br/>Repository ignore policy"]
+    end
   end
   actor_integrator["actor:integrator<br/>Connector integrator"]
   actor_maintainer["actor:maintainer<br/>Repository maintainer"]
@@ -13,4 +16,6 @@ flowchart TB
   actor_maintainer -->|"edge:maintainer_workspace<br/>edit working tree"| c_workspace
   c_workspace -->|"edge:workspace_remote<br/>git remote sync"| ext_github
   actor_integrator -->|"edge:integrator_github<br/>obtain repository"| ext_github
+  comp_git -->|"edge:git_remote_github<br/>origin remote"| ext_github
+  comp_ignore -->|"edge:ignore_npm_paths<br/>excludes node_modules and package caches"| ext_npm
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -2,5 +2,9 @@
 
 ```mermaid
 flowchart TD
-  boot["C4 generation started"]
+  actor_integrator["actor:integrator<br/>Connector integrator"]
+  actor_maintainer["actor:maintainer<br/>Repository maintainer"]
+  ext_github["ext:github<br/>GitHub"]
+  ext_npm["ext:npm_ecosystem<br/>Node/npm/Yarn ecosystem"]
+  actor_maintainer -->|"edge:maintainer_github<br/>git operations"| ext_github
 ```

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,1 +1,2 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
+{"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -2,3 +2,4 @@
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":18}
 {"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}
+{"pass":4,"status":"complete","artifact":"docs/c4-architecture.mermaid.md","seq_max":25}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,3 +1,4 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":18}
+{"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,0 +1,1 @@
+{"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,2 +1,3 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
+{"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":18}

--- a/docs/c4-pass1-runtime.json
+++ b/docs/c4-pass1-runtime.json
@@ -1,0 +1,17 @@
+{
+  "pass": 1,
+  "evidence_scope": "code_only",
+  "actors": [
+    {"id": "actor:integrator", "label": "Connector integrator", "evidence": "repository name decreen-connectors (remote URL path)"},
+    {"id": "actor:maintainer", "label": "Repository maintainer", "evidence": "git repository presence"}
+  ],
+  "externals": [
+    {"id": "ext:github", "label": "GitHub", "evidence": ".git/config remote origin URL host"},
+    {"id": "ext:npm_ecosystem", "label": "Node/npm/Yarn ecosystem", "evidence": ".gitignore patterns (node_modules, npm, yarn, vite, next, etc.)"}
+  ],
+  "deployables": [],
+  "excluded": [
+    {"id": "exclude:deployable_runtime", "reason": "No runnable service or library package manifest in tree"}
+  ],
+  "event_seq_range": [2, 9]
+}

--- a/docs/c4-pass2-l2.json
+++ b/docs/c4-pass2-l2.json
@@ -1,0 +1,21 @@
+{
+  "pass": 2,
+  "system_boundary": {
+    "id": "sys:decreen_connectors",
+    "label": "Decreen Connectors",
+    "evidence": "remote origin path decreen-connectors in .git/config"
+  },
+  "containers": [
+    {
+      "id": "container:local_repo_workspace",
+      "label": "Local repository workspace",
+      "evidence": "git repository with tracked tree; no separate deployable process identified"
+    }
+  ],
+  "excluded": [
+    {"id": "exclude:ci_runtime", "reason": "No .github or CI workflow files in tree"},
+    {"id": "exclude:container_image", "reason": "No Dockerfile in tree"},
+    {"id": "exclude:npm_package_app", "reason": "No package.json in tree"}
+  ],
+  "event_seq_range": [10, 18]
+}

--- a/docs/c4-pass3-l3.json
+++ b/docs/c4-pass3-l3.json
@@ -1,0 +1,25 @@
+{
+  "pass": 3,
+  "selected_containers": ["container:local_repo_workspace"],
+  "selection_note": "Single L2 container in stream; Pass 3 components scoped to it only",
+  "components": [
+    {
+      "id": "component:git_remote_integration",
+      "container_id": "container:local_repo_workspace",
+      "label": "Git remote integration",
+      "kinds": ["integration", "routing"],
+      "evidence": ".git/config remote origin URL and fetch refspec"
+    },
+    {
+      "id": "component:repo_ignore_policy",
+      "container_id": "container:local_repo_workspace",
+      "label": "Repository ignore policy",
+      "kinds": ["boundary", "state"],
+      "evidence": ".gitignore rules for dependencies, build outputs, env files"
+    }
+  ],
+  "excluded": [
+    {"id": "exclude:l3_second_container", "reason": "No additional containers to select"}
+  ],
+  "event_seq_range": [19, 24]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds an append-only C4 event stream under `docs/c4-events.ndjson` and derives live and final Mermaid diagrams from it. The model reflects **code/config evidence only** (`.git/config`, `.gitignore`); the workspace currently has no application source, so the architecture is minimal (repository workspace as the sole container).

## Artifacts

- `docs/c4-events.ndjson` — source of truth (seq 1–25, passes 0–4)
- `docs/c4-pass1-runtime.json` — Pass 1 runtime inventory
- `docs/c4-pass2-l2.json` — Pass 2 system boundary and containers
- `docs/c4-pass3-l3.json` — Pass 3 components (≤4 containers rule satisfied with one container)
- `docs/c4-architecture.mermaid.md` — L1, L2, L3, containment map
- `docs/c4-live.mermaid.md` — live projection (aligned with final L2+L3 view)
- `docs/c4-partial.ndjson` — progress checkpoints

## Commits (checkpoints)

1. Bootstrap placeholders
2. Pass 1
3. Pass 2
4. Pass 3
5. Pass 4 (final render + `freeze_pass` pass 4)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3f9ea3a-d701-4a62-aedc-001e52faaa7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3f9ea3a-d701-4a62-aedc-001e52faaa7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

