### PR TITLE
C4 architecture model from append-only event stream

### DIFF
--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,0 +1,3 @@
+# C4 Architecture
+
+_Not finalized yet._

--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,3 +1,59 @@
 # C4 Architecture
 
-_Not finalized yet._
+Projections from `docs/c4-events.ndjson` (append-only). Pass 4 adds no new elements.
+
+## L1 — System Context
+
+```mermaid
+flowchart TB
+  actor_dev["actor:dev — Developer"]
+  ext_github["ext:github — GitHub (git remote host)"]
+  sys_repo["sys:connectors-repo — Decreen Connectors (repository)"]
+  actor_dev -->|"edge:dev-sys — Maintains / edits"| sys_repo
+  sys_repo -->|"edge:sys-github — Remote origin / collaboration"| ext_github
+  actor_dev -->|"edge:dev-github — Git push / pull / browse"| ext_github
+```
+
+## L2 — Container diagram
+
+```mermaid
+flowchart TB
+  actor_dev["actor:dev — Developer"]
+  ext_github["ext:github — GitHub (git remote host)"]
+  subgraph sys_connectors["%% SCOPE: urn:c4:container:sys:connectors-repo<br/>sys:connectors-repo — Decreen Connectors (repository)"]
+    container_tracked["container:tracked-config — Tracked configuration and repository metadata"]
+  end
+  actor_dev -->|"edge:dev-sys — Maintains / edits"| sys_connectors
+  sys_connectors -->|"edge:sys-github — Remote origin / collaboration"| ext_github
+  actor_dev -->|"edge:dev-github — Git push / pull / browse"| ext_github
+```
+
+## L3 — container:tracked-config
+
+```mermaid
+flowchart TB
+  actor_dev["actor:dev — Developer"]
+  ext_github["ext:github — GitHub (git remote host)"]
+  subgraph sys_connectors["%% SCOPE: urn:c4:container:sys:connectors-repo"]
+    subgraph container_tracked["%% SCOPE: urn:c4:container:container:tracked-config<br/>container:tracked-config — Tracked configuration and repository metadata"]
+      component_ignore["%% KIND: boundary<br/>component:ignore-rules — Path ignore rules"]
+      component_origin["%% KIND: integration<br/>component:origin-link — Git remote origin configuration"]
+    end
+  end
+  actor_dev -->|"edge:dev-sys — Maintains / edits"| sys_connectors
+  sys_connectors -->|"edge:sys-github — Remote origin / collaboration"| ext_github
+  actor_dev -->|"edge:dev-github — Git push / pull / browse"| ext_github
+  actor_dev -->|"edge:dev-ignore — Edits ignore patterns"| component_ignore
+  component_origin -->|"edge:origin-github — Remote URL / fetch target"| ext_github
+  component_ignore -->|"edge:ignore-in-container — Part of"| container_tracked
+  component_origin -->|"edge:origin-in-container — Part of"| container_tracked
+```
+
+## Containment map
+
+| Element ID | Type | Contained in |
+|------------|------|----------------|
+| `sys:connectors-repo` | system | — |
+| `container:tracked-config` | container | `sys:connectors-repo` |
+| `component:ignore-rules` | component | `container:tracked-config` |
+| `component:origin-link` | component | `container:tracked-config` |

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,0 +1,1 @@
+{"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -5,3 +5,13 @@
 {"seq":5,"pass":1,"event":"add_edge","payload":{"id":"edge:dev-github","from":"actor:dev","to":"ext:github","label":"Git push / pull / browse"}}
 {"seq":6,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1-runtime","label":"Pass 1 runtime inventory","members":["actor:dev","ext:github"]}}
 {"seq":7,"pass":1,"event":"freeze_pass","payload":{"pass":1,"note":"Runtime actors and externals fixed; no deployable application units in snapshot."}}
+{"seq":8,"pass":2,"event":"set_system_boundary","payload":{"id":"sys:connectors-repo","label":"Decreen Connectors (repository snapshot)"}}
+{"seq":9,"pass":2,"event":"add_container","payload":{"id":"container:tracked-config","label":"Tracked configuration and repository metadata"}}
+{"seq":10,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container-api","reason":"No HTTP servers, OpenAPI, or route definitions in tracked source."}}
+{"seq":11,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container-worker","reason":"No job runners, queues, or worker entrypoints in tracked source."}}
+{"seq":12,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container-datastore","reason":"No database clients, migrations, or persistence config in tracked source."}}
+{"seq":13,"pass":2,"event":"add_edge","payload":{"id":"edge:dev-sys","from":"actor:dev","to":"sys:connectors-repo","label":"Maintains / edits"}}
+{"seq":14,"pass":2,"event":"add_edge","payload":{"id":"edge:sys-github","from":"sys:connectors-repo","to":"ext:github","label":"Remote origin / collaboration"}}
+{"seq":15,"pass":2,"event":"add_edge","payload":{"id":"edge:container-in-sys","from":"container:tracked-config","to":"sys:connectors-repo","label":"Contained within"}}
+{"seq":16,"pass":2,"event":"group_nodes","payload":{"id":"group:pass2-l2","label":"Pass 2 containers","members":["sys:connectors-repo","container:tracked-config"]}}
+{"seq":17,"pass":2,"event":"freeze_pass","payload":{"pass":2,"note":"System boundary and single container for in-repo artifacts fixed."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,1 +1,7 @@
 {"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}
+{"seq":2,"pass":1,"event":"add_actor","payload":{"id":"actor:dev","label":"Developer"}}
+{"seq":3,"pass":1,"event":"add_external","payload":{"id":"ext:github","label":"GitHub (git remote host)"}}
+{"seq":4,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:app-runtime","reason":"No application entrypoints, package manifests, Dockerfiles, or K8s manifests in tracked files; runtime inventory limited to repository metadata."}}
+{"seq":5,"pass":1,"event":"add_edge","payload":{"id":"edge:dev-github","from":"actor:dev","to":"ext:github","label":"Git push / pull / browse"}}
+{"seq":6,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1-runtime","label":"Pass 1 runtime inventory","members":["actor:dev","ext:github"]}}
+{"seq":7,"pass":1,"event":"freeze_pass","payload":{"pass":1,"note":"Runtime actors and externals fixed; no deployable application units in snapshot."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -15,3 +15,12 @@
 {"seq":15,"pass":2,"event":"add_edge","payload":{"id":"edge:container-in-sys","from":"container:tracked-config","to":"sys:connectors-repo","label":"Contained within"}}
 {"seq":16,"pass":2,"event":"group_nodes","payload":{"id":"group:pass2-l2","label":"Pass 2 containers","members":["sys:connectors-repo","container:tracked-config"]}}
 {"seq":17,"pass":2,"event":"freeze_pass","payload":{"pass":2,"note":"System boundary and single container for in-repo artifacts fixed."}}
+{"seq":18,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3-extra-containers","reason":"Only one L2 container exists in stream; Pass 3 selection is that container only (≤4 cap)."}}
+{"seq":19,"pass":3,"event":"add_component","payload":{"id":"component:ignore-rules","container":"container:tracked-config","label":"Path ignore rules","kind":"boundary"}}
+{"seq":20,"pass":3,"event":"add_component","payload":{"id":"component:origin-link","container":"container:tracked-config","label":"Git remote origin configuration","kind":"integration"}}
+{"seq":21,"pass":3,"event":"add_edge","payload":{"id":"edge:dev-ignore","from":"actor:dev","to":"component:ignore-rules","label":"Edits ignore patterns"}}
+{"seq":22,"pass":3,"event":"add_edge","payload":{"id":"edge:origin-github","from":"component:origin-link","to":"ext:github","label":"Remote URL / fetch target"}}
+{"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:ignore-in-container","from":"component:ignore-rules","to":"container:tracked-config","label":"Part of"}}
+{"seq":24,"pass":3,"event":"add_edge","payload":{"id":"edge:origin-in-container","from":"component:origin-link","to":"container:tracked-config","label":"Part of"}}
+{"seq":25,"pass":3,"event":"group_nodes","payload":{"id":"group:pass3-l3","label":"Pass 3 L3 targets","members":["container:tracked-config"]}}
+{"seq":26,"pass":3,"event":"freeze_pass","payload":{"pass":3,"note":"L3 components for tracked-config fixed."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -24,3 +24,5 @@
 {"seq":24,"pass":3,"event":"add_edge","payload":{"id":"edge:origin-in-container","from":"component:origin-link","to":"container:tracked-config","label":"Part of"}}
 {"seq":25,"pass":3,"event":"group_nodes","payload":{"id":"group:pass3-l3","label":"Pass 3 L3 targets","members":["container:tracked-config"]}}
 {"seq":26,"pass":3,"event":"freeze_pass","payload":{"pass":3,"note":"L3 components for tracked-config fixed."}}
+{"seq":27,"pass":4,"event":"refine_label","payload":{"id":"sys:connectors-repo","label":"Decreen Connectors (repository)"}}
+{"seq":28,"pass":4,"event":"freeze_pass","payload":{"pass":4,"note":"Final render frozen; diagrams are projections of the event stream."}}

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -2,9 +2,9 @@
 
 ```mermaid
 flowchart TB
-  actor_dev["Developer"]
-  ext_github["GitHub (git remote host)"]
-  subgraph sys_connectors["sys:connectors-repo — Decreen Connectors (repository snapshot)"]
+  actor_dev["actor:dev — Developer"]
+  ext_github["ext:github — GitHub (git remote host)"]
+  subgraph sys_connectors["sys:connectors-repo — Decreen Connectors (repository)"]
     subgraph container_tracked["container:tracked-config — Tracked configuration and repository metadata"]
       component_ignore["component:ignore-rules — Path ignore rules"]
       component_origin["component:origin-link — Git remote origin configuration"]
@@ -15,4 +15,6 @@ flowchart TB
   actor_dev -->|"Git push / pull / browse"| ext_github
   actor_dev -->|"Edits ignore patterns"| component_ignore
   component_origin -->|"Remote URL / fetch target"| ext_github
+  component_ignore -->|"Part of"| container_tracked
+  component_origin -->|"Part of"| container_tracked
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,8 +1,13 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart LR
+flowchart TB
   actor_dev["Developer"]
   ext_github["GitHub (git remote host)"]
+  subgraph sys_connectors["Decreen Connectors (repository snapshot)"]
+    container_tracked["Tracked configuration and repository metadata"]
+  end
+  actor_dev -->|"Maintains / edits"| sys_connectors
+  sys_connectors -->|"Remote origin / collaboration"| ext_github
   actor_dev -->|"Git push / pull / browse"| ext_github
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,6 +1,8 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart TD
-  boot["C4 generation started"]
+flowchart LR
+  actor_dev["Developer"]
+  ext_github["GitHub (git remote host)"]
+  actor_dev -->|"Git push / pull / browse"| ext_github
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -4,10 +4,15 @@
 flowchart TB
   actor_dev["Developer"]
   ext_github["GitHub (git remote host)"]
-  subgraph sys_connectors["Decreen Connectors (repository snapshot)"]
-    container_tracked["Tracked configuration and repository metadata"]
+  subgraph sys_connectors["sys:connectors-repo — Decreen Connectors (repository snapshot)"]
+    subgraph container_tracked["container:tracked-config — Tracked configuration and repository metadata"]
+      component_ignore["component:ignore-rules — Path ignore rules"]
+      component_origin["component:origin-link — Git remote origin configuration"]
+    end
   end
   actor_dev -->|"Maintains / edits"| sys_connectors
   sys_connectors -->|"Remote origin / collaboration"| ext_github
   actor_dev -->|"Git push / pull / browse"| ext_github
+  actor_dev -->|"Edits ignore patterns"| component_ignore
+  component_origin -->|"Remote URL / fetch target"| ext_github
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,0 +1,6 @@
+# Live C4 Preview
+
+```mermaid
+flowchart TD
+  boot["C4 generation started"]
+```

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,2 +1,3 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}
+{"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":17}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,1 +1,2 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
+{"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,0 +1,1 @@
+{"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -2,3 +2,4 @@
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":17}
 {"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":26}
+{"pass":4,"status":"complete","artifact":"docs/c4-architecture.mermaid.md","seq_max":28}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,3 +1,4 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":17}
+{"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":26}

--- a/docs/c4-pass1-runtime.json
+++ b/docs/c4-pass1-runtime.json
@@ -1,0 +1,24 @@
+{
+  "pass": 1,
+  "actors": [{ "id": "actor:dev", "label": "Developer" }],
+  "externals": [{ "id": "ext:github", "label": "GitHub (git remote host)" }],
+  "deployables": [],
+  "excluded": [
+    {
+      "id": "candidate:app-runtime",
+      "reason": "No application entrypoints, package manifests, Dockerfiles, or K8s manifests in tracked files; runtime inventory limited to repository metadata."
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:dev-github",
+      "from": "actor:dev",
+      "to": "ext:github",
+      "label": "Git push / pull / browse"
+    }
+  ],
+  "evidence": [
+    "Remote URL https://github.com/Decreen/decreen-connectors in .git/config",
+    "Tracked files: .gitignore, LICENSE, README.md only (plus C4 docs)"
+  ]
+}

--- a/docs/c4-pass2-l2.json
+++ b/docs/c4-pass2-l2.json
@@ -1,0 +1,17 @@
+{
+  "pass": 2,
+  "system": { "id": "sys:connectors-repo", "label": "Decreen Connectors (repository snapshot)" },
+  "containers": [
+    { "id": "container:tracked-config", "label": "Tracked configuration and repository metadata" }
+  ],
+  "excluded": [
+    { "id": "candidate:container-api", "reason": "No HTTP servers, OpenAPI, or route definitions in tracked source." },
+    { "id": "candidate:container-worker", "reason": "No job runners, queues, or worker entrypoints in tracked source." },
+    { "id": "candidate:container-datastore", "reason": "No database clients, migrations, or persistence config in tracked source." }
+  ],
+  "edges": [
+    { "id": "edge:dev-sys", "from": "actor:dev", "to": "sys:connectors-repo", "label": "Maintains / edits" },
+    { "id": "edge:sys-github", "from": "sys:connectors-repo", "to": "ext:github", "label": "Remote origin / collaboration" },
+    { "id": "edge:container-in-sys", "from": "container:tracked-config", "to": "sys:connectors-repo", "label": "Contained within" }
+  ]
+}

--- a/docs/c4-pass3-l3.json
+++ b/docs/c4-pass3-l3.json
@@ -1,0 +1,32 @@
+{
+  "pass": 3,
+  "selected_containers": ["container:tracked-config"],
+  "components": [
+    {
+      "id": "component:ignore-rules",
+      "container": "container:tracked-config",
+      "label": "Path ignore rules",
+      "kind": "boundary",
+      "aspects": ["routing", "state"]
+    },
+    {
+      "id": "component:origin-link",
+      "container": "container:tracked-config",
+      "label": "Git remote origin configuration",
+      "kind": "integration",
+      "aspects": ["routing", "integration"]
+    }
+  ],
+  "excluded": [
+    {
+      "id": "candidate:l3-extra-containers",
+      "reason": "Only one L2 container exists in stream; Pass 3 selection is that container only (≤4 cap)."
+    }
+  ],
+  "edges": [
+    { "id": "edge:dev-ignore", "from": "actor:dev", "to": "component:ignore-rules", "label": "Edits ignore patterns" },
+    { "id": "edge:origin-github", "from": "component:origin-link", "to": "ext:github", "label": "Remote URL / fetch target" },
+    { "id": "edge:ignore-in-container", "from": "component:ignore-rules", "to": "container:tracked-config", "label": "Part of" },
+    { "id": "edge:origin-in-container", "from": "component:origin-link", "to": "container:tracked-config", "label": "Part of" }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change introduces a C4-style architecture model driven by an append-only event stream in `docs/c4-events.ndjson`. All diagrams and pass artifacts are projections of that stream.

## Evidence scope

Runtime and repository evidence was taken from **code and executable configuration only** (e.g. `.git/config`, `.gitignore`, tracked file inventory). Repository prose (`README.md`, etc.) was not used as architecture evidence.

## Repository note

The current snapshot has **no application source** in tracked files (only `.gitignore`, `LICENSE`, `README.md`, and these C4 outputs). The model reflects that: one L2 container for tracked configuration/metadata, with L3 components for `.gitignore` rules and git remote origin.

## Commits (checkpoints)

1. Bootstrap: event stream + placeholder diagrams  
2. Pass 1: runtime inventory → `docs/c4-pass1-runtime.json`  
3. Pass 2: system boundary + containers → `docs/c4-pass2-l2.json`  
4. Pass 3: L3 components → `docs/c4-pass3-l3.json`  
5. Pass 4: final mermaid in `docs/c4-architecture.mermaid.md` + `freeze_pass`

## Files

| File | Role |
|------|------|
| `docs/c4-events.ndjson` | Source of truth (append-only) |
| `docs/c4-live.mermaid.md` | Live projection |
| `docs/c4-architecture.mermaid.md` | Final L1/L2/L3 + containment map |
| `docs/c4-partial.ndjson` | Progress index |
| `docs/c4-pass{1,2,3}-*.json` | Pass snapshots |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3646008a-cc8e-4ae6-90a6-7db0d14f1b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3646008a-cc8e-4ae6-90a6-7db0d14f1b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

