### PR TITLE
C4 architecture from append-only event stream

### DIFF
--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,3 +1,56 @@
 # C4 Architecture
 
-_Not finalized yet._
+Derived from `docs/c4-events.ndjson` (append-only stream). Pass 4 adds no new elements.
+
+## L1 — System context
+
+```mermaid
+flowchart LR
+  actor_developer["Developer"]
+  ext_github["GitHub"]
+  ext_npm["npm package registry"]
+  ext_license["Apache License 2.0 terms"]
+  sys_boundary["Decreen Connectors (repository)"]
+  actor_developer -->|"uses Git remote"| ext_github
+  actor_developer -->|"consumes packages (implied by ignore rules)"| ext_npm
+  actor_developer -->|"maintains"| sys_boundary
+```
+
+## L2 — Containers
+
+```mermaid
+flowchart TB
+  sys_boundary["Decreen Connectors (repository)"]
+  ctr_bootstrap["Repository bootstrap (config-only)"]
+  ext_github["GitHub"]
+  ext_license["Apache License 2.0 terms"]
+  sys_boundary --- ctr_bootstrap
+  ctr_bootstrap -->|"source hosted at"| ext_github
+  ctr_bootstrap -->|"distributes under"| ext_license
+```
+
+## L3 — Components (container: `repo_bootstrap`)
+
+```mermaid
+flowchart TB
+  subgraph repo_bootstrap["%% SCOPE: urn:c4:container:repo_bootstrap"]
+    comp_npm["%% KIND: integration\nnpm/Node ecosystem integration"]
+    comp_build["%% KIND: pipeline\nBuild output path exclusions"]
+  end
+```
+
+## Containment Map
+
+```json
+{
+  "parentToChildren": {
+    "decreen_connectors": ["repo_bootstrap"],
+    "repo_bootstrap": ["npm_ecosystem_integration", "build_output_pipeline"]
+  },
+  "childToParent": {
+    "repo_bootstrap": "decreen_connectors",
+    "npm_ecosystem_integration": "repo_bootstrap",
+    "build_output_pipeline": "repo_bootstrap"
+  }
+}
+```

--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,0 +1,3 @@
+# C4 Architecture
+
+_Not finalized yet._

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,0 +1,1 @@
+{"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -7,3 +7,13 @@
 {"seq":7,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1_runtime","label":"Pass 1 runtime inventory","members":["actor:developer","ext:npm_registry","ext:github","ext:apache_license"]}}
 {"seq":8,"pass":1,"event":"add_edge","payload":{"id":"edge:developer_github","from":"actor:developer","to":"ext:github","label":"uses Git remote"}}
 {"seq":9,"pass":1,"event":"freeze_pass","payload":{"pass":1,"note":"Runtime inventory from .gitignore, LICENSE, and .git/config only."}}
+{"seq":10,"pass":2,"event":"set_system_boundary","payload":{"id":"sys:decreen_connectors","label":"Decreen Connectors"}}
+{"seq":11,"pass":2,"event":"add_container","payload":{"id":"container:repo_bootstrap","label":"Repository bootstrap (config-only)"}}
+{"seq":12,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_web_app","reason":"No web server, static host, or frontend entrypoint present in tracked files."}}
+{"seq":13,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_api","reason":"No API server or HTTP handler code present in tracked files."}}
+{"seq":14,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_worker","reason":"No worker, job runner, or scheduler process present in tracked files."}}
+{"seq":15,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_database","reason":"No database, migration, or persistence layer present in tracked files."}}
+{"seq":16,"pass":2,"event":"add_edge","payload":{"id":"edge:bootstrap_github","from":"container:repo_bootstrap","to":"ext:github","label":"source hosted at"}}
+{"seq":17,"pass":2,"event":"add_edge","payload":{"id":"edge:bootstrap_license","from":"container:repo_bootstrap","to":"ext:apache_license","label":"distributes under"}}
+{"seq":18,"pass":2,"event":"add_edge","payload":{"id":"edge:developer_system","from":"actor:developer","to":"sys:decreen_connectors","label":"maintains"}}
+{"seq":19,"pass":2,"event":"freeze_pass","payload":{"pass":2,"note":"L2 reflects config-only repository; single container inside system boundary."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -17,3 +17,8 @@
 {"seq":17,"pass":2,"event":"add_edge","payload":{"id":"edge:bootstrap_license","from":"container:repo_bootstrap","to":"ext:apache_license","label":"distributes under"}}
 {"seq":18,"pass":2,"event":"add_edge","payload":{"id":"edge:developer_system","from":"actor:developer","to":"sys:decreen_connectors","label":"maintains"}}
 {"seq":19,"pass":2,"event":"freeze_pass","payload":{"pass":2,"note":"L2 reflects config-only repository; single container inside system boundary."}}
+{"seq":20,"pass":3,"event":"add_component","payload":{"id":"component:npm_ecosystem_integration","label":"npm/Node ecosystem integration","container":"container:repo_bootstrap","kind":"integration"}}
+{"seq":21,"pass":3,"event":"add_component","payload":{"id":"component:build_output_pipeline","label":"Build output path exclusions","container":"container:repo_bootstrap","kind":"pipeline"}}
+{"seq":22,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3_extra_containers","reason":"Only one substantiated container in stream; Pass 3 selection is container:repo_bootstrap only."}}
+{"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:developer_npm_registry","from":"actor:developer","to":"ext:npm_registry","label":"consumes packages (implied by ignore rules)"}}
+{"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3,"note":"L3 components grounded in .gitignore Node and build-output patterns."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -22,3 +22,5 @@
 {"seq":22,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3_extra_containers","reason":"Only one substantiated container in stream; Pass 3 selection is container:repo_bootstrap only."}}
 {"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:developer_npm_registry","from":"actor:developer","to":"ext:npm_registry","label":"consumes packages (implied by ignore rules)"}}
 {"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3,"note":"L3 components grounded in .gitignore Node and build-output patterns."}}
+{"seq":25,"pass":4,"event":"refine_label","payload":{"id":"sys:decreen_connectors","label":"Decreen Connectors (repository)"}}
+{"seq":26,"pass":4,"event":"freeze_pass","payload":{"pass":4,"note":"Final render from stream only; no new elements."}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,1 +1,9 @@
 {"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}
+{"seq":2,"pass":1,"event":"add_actor","payload":{"id":"actor:developer","label":"Developer"}}
+{"seq":3,"pass":1,"event":"add_external","payload":{"id":"ext:npm_registry","label":"npm package registry"}}
+{"seq":4,"pass":1,"event":"add_external","payload":{"id":"ext:github","label":"GitHub"}}
+{"seq":5,"pass":1,"event":"add_external","payload":{"id":"ext:apache_license","label":"Apache License 2.0 terms"}}
+{"seq":6,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:app_deployable","reason":"No application entrypoint, manifest, or container config present in tracked source; repository is bootstrap-only."}}
+{"seq":7,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1_runtime","label":"Pass 1 runtime inventory","members":["actor:developer","ext:npm_registry","ext:github","ext:apache_license"]}}
+{"seq":8,"pass":1,"event":"add_edge","payload":{"id":"edge:developer_github","from":"actor:developer","to":"ext:github","label":"uses Git remote"}}
+{"seq":9,"pass":1,"event":"freeze_pass","payload":{"pass":1,"note":"Runtime inventory from .gitignore, LICENSE, and .git/config only."}}

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,12 +1,18 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart LR
-  subgraph L1["System context (Pass 1)"]
+flowchart TB
+  subgraph L1["Context"]
     actor_developer["Developer"]
     ext_github["GitHub"]
     ext_npm["npm package registry"]
     ext_license["Apache License 2.0 terms"]
   end
+  subgraph L2["Decreen Connectors (system)"]
+    ctr_bootstrap["Repository bootstrap (config-only)"]
+  end
   actor_developer -->|"uses Git remote"| ext_github
+  actor_developer -->|"maintains"| L2
+  ctr_bootstrap -->|"source hosted at"| ext_github
+  ctr_bootstrap -->|"distributes under"| ext_license
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,6 +1,12 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart TD
-  boot["C4 generation started"]
+flowchart LR
+  subgraph L1["System context (Pass 1)"]
+    actor_developer["Developer"]
+    ext_github["GitHub"]
+    ext_npm["npm package registry"]
+    ext_license["Apache License 2.0 terms"]
+  end
+  actor_developer -->|"uses Git remote"| ext_github
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,0 +1,6 @@
+# Live C4 Preview
+
+```mermaid
+flowchart TD
+  boot["C4 generation started"]
+```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -7,16 +7,21 @@ flowchart TB
     ext_github["GitHub"]
     ext_npm["npm package registry"]
     ext_license["Apache License 2.0 terms"]
+    sys_boundary["Decreen Connectors (repository)"]
   end
-  subgraph SYS["L2 — Decreen Connectors"]
-    subgraph CTR["%% SCOPE: urn:c4:container:repo_bootstrap"]
-      comp_npm["%% KIND: integration\nnpm/Node ecosystem integration"]
-      comp_build["%% KIND: pipeline\nBuild output path exclusions"]
-    end
+  subgraph SYS["L2 — Containers"]
+    ctr_bootstrap["Repository bootstrap (config-only)"]
+  end
+  subgraph L3["%% SCOPE: urn:c4:container:repo_bootstrap"]
+    comp_npm["%% KIND: integration\nnpm/Node ecosystem integration"]
+    comp_build["%% KIND: pipeline\nBuild output path exclusions"]
   end
   actor_developer -->|"uses Git remote"| ext_github
   actor_developer -->|"consumes packages (implied by ignore rules)"| ext_npm
-  actor_developer -->|"maintains"| SYS
-  CTR -->|"source hosted at"| ext_github
-  CTR -->|"distributes under"| ext_license
+  actor_developer -->|"maintains"| sys_boundary
+  sys_boundary --- ctr_bootstrap
+  ctr_bootstrap --> comp_npm
+  ctr_bootstrap --> comp_build
+  ctr_bootstrap -->|"source hosted at"| ext_github
+  ctr_bootstrap -->|"distributes under"| ext_license
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -2,17 +2,21 @@
 
 ```mermaid
 flowchart TB
-  subgraph L1["Context"]
+  subgraph CTX["L1 — System context"]
     actor_developer["Developer"]
     ext_github["GitHub"]
     ext_npm["npm package registry"]
     ext_license["Apache License 2.0 terms"]
   end
-  subgraph L2["Decreen Connectors (system)"]
-    ctr_bootstrap["Repository bootstrap (config-only)"]
+  subgraph SYS["L2 — Decreen Connectors"]
+    subgraph CTR["%% SCOPE: urn:c4:container:repo_bootstrap"]
+      comp_npm["%% KIND: integration\nnpm/Node ecosystem integration"]
+      comp_build["%% KIND: pipeline\nBuild output path exclusions"]
+    end
   end
   actor_developer -->|"uses Git remote"| ext_github
-  actor_developer -->|"maintains"| L2
-  ctr_bootstrap -->|"source hosted at"| ext_github
-  ctr_bootstrap -->|"distributes under"| ext_license
+  actor_developer -->|"consumes packages (implied by ignore rules)"| ext_npm
+  actor_developer -->|"maintains"| SYS
+  CTR -->|"source hosted at"| ext_github
+  CTR -->|"distributes under"| ext_license
 ```

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,1 +1,2 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
+{"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,2 +1,3 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
+{"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":19}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,0 +1,1 @@
+{"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -2,3 +2,4 @@
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":19}
 {"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}
+{"pass":4,"status":"complete","artifact":"docs/c4-architecture.mermaid.md","seq_max":26}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,3 +1,4 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":9}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":19}
+{"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}

--- a/docs/c4-pass1-runtime.json
+++ b/docs/c4-pass1-runtime.json
@@ -1,0 +1,19 @@
+{
+  "pass": 1,
+  "actors": [
+    {"id": "actor:developer", "label": "Developer"}
+  ],
+  "externals": [
+    {"id": "ext:npm_registry", "label": "npm package registry"},
+    {"id": "ext:github", "label": "GitHub"},
+    {"id": "ext:apache_license", "label": "Apache License 2.0 terms"}
+  ],
+  "deployables": [],
+  "excluded": [
+    {"id": "candidate:app_deployable", "reason": "No application entrypoint, manifest, or container config present in tracked source; repository is bootstrap-only."}
+  ],
+  "edges": [
+    {"id": "edge:developer_github", "from": "actor:developer", "to": "ext:github", "label": "uses Git remote"}
+  ],
+  "seq_max": 9
+}

--- a/docs/c4-pass2-l2.json
+++ b/docs/c4-pass2-l2.json
@@ -1,0 +1,19 @@
+{
+  "pass": 2,
+  "system": {"id": "sys:decreen_connectors", "label": "Decreen Connectors"},
+  "containers": [
+    {"id": "container:repo_bootstrap", "label": "Repository bootstrap (config-only)"}
+  ],
+  "excluded": [
+    {"id": "candidate:container_web_app", "reason": "No web server, static host, or frontend entrypoint present in tracked files."},
+    {"id": "candidate:container_api", "reason": "No API server or HTTP handler code present in tracked files."},
+    {"id": "candidate:container_worker", "reason": "No worker, job runner, or scheduler process present in tracked files."},
+    {"id": "candidate:container_database", "reason": "No database, migration, or persistence layer present in tracked files."}
+  ],
+  "edges": [
+    {"id": "edge:bootstrap_github", "from": "container:repo_bootstrap", "to": "ext:github", "label": "source hosted at"},
+    {"id": "edge:bootstrap_license", "from": "container:repo_bootstrap", "to": "ext:apache_license", "label": "distributes under"},
+    {"id": "edge:developer_system", "from": "actor:developer", "to": "sys:decreen_connectors", "label": "maintains"}
+  ],
+  "seq_max": 19
+}

--- a/docs/c4-pass3-l3.json
+++ b/docs/c4-pass3-l3.json
@@ -1,0 +1,25 @@
+{
+  "pass": 3,
+  "selected_containers": ["container:repo_bootstrap"],
+  "components": [
+    {
+      "id": "component:npm_ecosystem_integration",
+      "label": "npm/Node ecosystem integration",
+      "container": "container:repo_bootstrap",
+      "kind": "integration"
+    },
+    {
+      "id": "component:build_output_pipeline",
+      "label": "Build output path exclusions",
+      "container": "container:repo_bootstrap",
+      "kind": "pipeline"
+    }
+  ],
+  "excluded": [
+    {"id": "candidate:l3_extra_containers", "reason": "Only one substantiated container in stream; Pass 3 selection is container:repo_bootstrap only."}
+  ],
+  "edges": [
+    {"id": "edge:developer_npm_registry", "from": "actor:developer", "to": "ext:npm_registry", "label": "consumes packages (implied by ignore rules)"}
+  ],
+  "seq_max": 24
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change introduces a C4 model driven by an append-only event stream in `docs/c4-events.ndjson`, with pass artifacts (`docs/c4-pass1-runtime.json` through `docs/c4-pass3-l3.json`), a live Mermaid projection in `docs/c4-live.mermaid.md`, and the final diagram in `docs/c4-architecture.mermaid.md`.

**Evidence scope:** The repository on `main` currently contains only `.gitignore`, `LICENSE`, and `README.md`. Architecture was inferred from executable/config-like artifacts only (`.gitignore`, `LICENSE`, `.git/config`), not from `README.md` or other prose docs, per the code-only scope policy.

**Checkpoints:** Bootstrap plus Pass 1–4 each have a single commit and were pushed to `cursor/c4-architecture-event-stream-781b`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-714eb32f-e5b4-481a-8581-34e2c1f23e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-714eb32f-e5b4-481a-8581-34e2c1f23e63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

