### PR TITLE
C4 architecture: append-only event stream and projections

### DIFF
--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,0 +1,3 @@
+# C4 Architecture
+
+_Not finalized yet._

--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,3 +1,65 @@
 # C4 Architecture
 
-_Not finalized yet._
+## L1 — System context
+
+```mermaid
+flowchart LR
+  dev(("actor:developer\nDeveloper"))
+  gh["ext:github_hosting\nGitHub"]
+  sys["sys:decreen_connectors\nDecreen connectors platform repository"]
+  dev -->|"edge:dev_maintains_repo\nmaintains repository"| sys
+  gh -->|"edge:github_hosts_repo\nhosts remote repository"| sys
+  dev -->|"edge:dev_git_remote\ngit clone/fetch/push"| gh
+```
+
+## L2 — Container diagram
+
+```mermaid
+flowchart TB
+  subgraph sys_boundary["sys:decreen_connectors — Decreen connectors platform repository"]
+    ctr_src["container:tracked_sources\nTracked source files"]
+    ctr_git["container:scm_integration\nGit / SCM integration"]
+  end
+```
+
+## L3 — container:tracked_sources
+
+```mermaid
+flowchart TB
+  subgraph scoped["%% SCOPE: urn:c4:container:tracked_sources"]
+    c1["component:tracked_license_and_ignore\n%% KIND: storage"]
+    c2["component:repository_tree_boundary\n%% KIND: boundary"]
+  end
+```
+
+## L3 — container:scm_integration
+
+```mermaid
+flowchart TB
+  subgraph scoped["%% SCOPE: urn:c4:container:scm_integration"]
+    c3["component:git_origin_remote\n%% KIND: integration"]
+    c4["component:git_hooks_path\n%% KIND: scheduler"]
+    c4 -->|"edge:hooks_invoke_remote_ops"| c3
+  end
+  c3 -->|"edge:scm_views_tracked_tree"| c2["component:repository_tree_boundary\n%% KIND: boundary"]
+```
+
+## Containment Map
+
+```json
+{
+  "parentToChildren": {
+    "sys:decreen_connectors": ["container:tracked_sources", "container:scm_integration"],
+    "container:tracked_sources": ["component:tracked_license_and_ignore", "component:repository_tree_boundary"],
+    "container:scm_integration": ["component:git_origin_remote", "component:git_hooks_path"]
+  },
+  "childToParent": {
+    "container:tracked_sources": "sys:decreen_connectors",
+    "container:scm_integration": "sys:decreen_connectors",
+    "component:tracked_license_and_ignore": "container:tracked_sources",
+    "component:repository_tree_boundary": "container:tracked_sources",
+    "component:git_origin_remote": "container:scm_integration",
+    "component:git_hooks_path": "container:scm_integration"
+  }
+}
+```

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,0 +1,1 @@
+{"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,1 +1,7 @@
 {"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}
+{"seq":2,"pass":1,"event":"add_actor","payload":{"id":"actor:developer","label":"Developer"}}
+{"seq":3,"pass":1,"event":"add_external","payload":{"id":"ext:github_hosting","label":"GitHub","description":"Git remote host from .git/config origin URL"}}
+{"seq":4,"pass":1,"event":"exclude_candidate","payload":{"kind":"deployable","reason":"No application entrypoints, manifests, Dockerfiles, or CI workflow files present in repository tree beyond LICENSE, .gitignore, and docs/"}}
+{"seq":5,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1_runtime","label":"Pass 1 runtime inventory","members":["actor:developer","ext:github_hosting"]}}
+{"seq":6,"pass":1,"event":"add_edge","payload":{"id":"edge:dev_git_remote","from":"actor:developer","to":"ext:github_hosting","label":"git clone/fetch/push"}}
+{"seq":7,"pass":1,"event":"freeze_pass","payload":{"pass":1}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -14,3 +14,13 @@
 {"seq":14,"pass":2,"event":"add_edge","payload":{"id":"edge:github_hosts_repo","from":"ext:github_hosting","to":"sys:decreen_connectors","label":"hosts remote repository"}}
 {"seq":15,"pass":2,"event":"group_nodes","payload":{"id":"group:l2_inside_system","label":"Inside sys:decreen_connectors","members":["container:tracked_sources","container:scm_integration"]}}
 {"seq":16,"pass":2,"event":"freeze_pass","payload":{"pass":2}}
+{"seq":17,"pass":3,"event":"add_component","payload":{"id":"component:tracked_license_and_ignore","label":"License and ignore policy files","parent":"container:tracked_sources","kind":"storage","aspects":["state","subsystems"]}}
+{"seq":18,"pass":3,"event":"add_component","payload":{"id":"component:repository_tree_boundary","label":"Repository file tree boundary","parent":"container:tracked_sources","kind":"boundary","aspects":["routing","state"]}}
+{"seq":19,"pass":3,"event":"add_component","payload":{"id":"component:git_origin_remote","label":"Origin remote configuration","parent":"container:scm_integration","kind":"integration","aspects":["routing","API"]}}
+{"seq":20,"pass":3,"event":"add_component","payload":{"id":"component:git_hooks_path","label":"Git hooks path configuration","parent":"container:scm_integration","kind":"scheduler","aspects":["processing","subsystems"]}}
+{"seq":21,"pass":3,"event":"exclude_candidate","payload":{"kind":"component","id":"candidate:readme_as_component","reason":"README excluded from evidence scope"}}
+{"seq":22,"pass":3,"event":"add_edge","payload":{"id":"edge:hooks_invoke_remote_ops","from":"component:git_hooks_path","to":"component:git_origin_remote","label":"precedes / accompanies git operations"}}
+{"seq":23,"pass":3,"event":"add_edge","payload":{"id":"edge:scm_views_tracked_tree","from":"component:git_origin_remote","to":"component:repository_tree_boundary","label":"versioned tree"}}
+{"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3}}
+{"seq":25,"pass":4,"event":"refine_label","payload":{"id":"sys:decreen_connectors","label":"Decreen connectors platform repository"}}
+{"seq":26,"pass":4,"event":"freeze_pass","payload":{"pass":4}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -5,3 +5,12 @@
 {"seq":5,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1_runtime","label":"Pass 1 runtime inventory","members":["actor:developer","ext:github_hosting"]}}
 {"seq":6,"pass":1,"event":"add_edge","payload":{"id":"edge:dev_git_remote","from":"actor:developer","to":"ext:github_hosting","label":"git clone/fetch/push"}}
 {"seq":7,"pass":1,"event":"freeze_pass","payload":{"pass":1}}
+{"seq":8,"pass":2,"event":"set_system_boundary","payload":{"id":"sys:decreen_connectors","label":"Decreen connectors (repository)","description":"Software system identified from git remote origin path Decreen/decreen-connectors"}}
+{"seq":9,"pass":2,"event":"add_container","payload":{"id":"container:tracked_sources","label":"Tracked source files","technology":"files in repository root","description":"LICENSE and .gitignore present as tracked artifacts"}}
+{"seq":10,"pass":2,"event":"add_container","payload":{"id":"container:scm_integration","label":"Git / SCM integration","technology":"git","description":".git/config defines origin remote and hooksPath"}}
+{"seq":11,"pass":2,"event":"exclude_candidate","payload":{"kind":"container","id":"candidate:readme_docs","reason":"README and docs/ excluded as documentation-only evidence per source scope policy"}}
+{"seq":12,"pass":2,"event":"exclude_candidate","payload":{"kind":"container","id":"candidate:runtime_services","reason":"No Docker, Kubernetes, workflow, or application manifests found in tree"}}
+{"seq":13,"pass":2,"event":"add_edge","payload":{"id":"edge:dev_maintains_repo","from":"actor:developer","to":"sys:decreen_connectors","label":"maintains repository"}}
+{"seq":14,"pass":2,"event":"add_edge","payload":{"id":"edge:github_hosts_repo","from":"ext:github_hosting","to":"sys:decreen_connectors","label":"hosts remote repository"}}
+{"seq":15,"pass":2,"event":"group_nodes","payload":{"id":"group:l2_inside_system","label":"Inside sys:decreen_connectors","members":["container:tracked_sources","container:scm_integration"]}}
+{"seq":16,"pass":2,"event":"freeze_pass","payload":{"pass":2}}

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,6 +1,10 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart TD
-  boot["C4 generation started"]
+flowchart LR
+  subgraph L1["System context (Pass 1)"]
+    dev(("actor:developer\nDeveloper"))
+    gh["ext:github_hosting\nGitHub"]
+    dev -->|"edge:dev_git_remote\ngit clone/fetch/push"| gh
+  end
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -4,11 +4,19 @@
 flowchart TB
   dev(("actor:developer\nDeveloper"))
   gh["ext:github_hosting\nGitHub"]
-  subgraph sys_boundary["sys:decreen_connectors — Decreen connectors (repository)"]
-    ctr_src["container:tracked_sources\nTracked source files"]
-    ctr_git["container:scm_integration\nGit / SCM integration"]
+  subgraph sys_boundary["sys:decreen_connectors — Decreen connectors platform repository"]
+    subgraph ctr_src["container:tracked_sources"]
+      c1["component:tracked_license_and_ignore\n%% KIND: storage"]
+      c2["component:repository_tree_boundary\n%% KIND: boundary"]
+    end
+    subgraph ctr_git["container:scm_integration"]
+      c3["component:git_origin_remote\n%% KIND: integration"]
+      c4["component:git_hooks_path\n%% KIND: scheduler"]
+    end
+    c4 -->|"edge:hooks_invoke_remote_ops"| c3
+    c3 -->|"edge:scm_views_tracked_tree"| c2
   end
-  dev -->|"edge:dev_maintains_repo\nmaintains repository"| sys_boundary
-  gh -->|"edge:github_hosts_repo\nhosts remote repository"| sys_boundary
-  dev -->|"edge:dev_git_remote\ngit clone/fetch/push"| gh
+  dev -->|"edge:dev_maintains_repo"| sys_boundary
+  gh -->|"edge:github_hosts_repo"| sys_boundary
+  dev -->|"edge:dev_git_remote"| gh
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,0 +1,6 @@
+# Live C4 Preview
+
+```mermaid
+flowchart TD
+  boot["C4 generation started"]
+```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,10 +1,14 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart LR
-  subgraph L1["System context (Pass 1)"]
-    dev(("actor:developer\nDeveloper"))
-    gh["ext:github_hosting\nGitHub"]
-    dev -->|"edge:dev_git_remote\ngit clone/fetch/push"| gh
+flowchart TB
+  dev(("actor:developer\nDeveloper"))
+  gh["ext:github_hosting\nGitHub"]
+  subgraph sys_boundary["sys:decreen_connectors — Decreen connectors (repository)"]
+    ctr_src["container:tracked_sources\nTracked source files"]
+    ctr_git["container:scm_integration\nGit / SCM integration"]
   end
+  dev -->|"edge:dev_maintains_repo\nmaintains repository"| sys_boundary
+  gh -->|"edge:github_hosts_repo\nhosts remote repository"| sys_boundary
+  dev -->|"edge:dev_git_remote\ngit clone/fetch/push"| gh
 ```

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,2 +1,3 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}
+{"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":16}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,1 +1,2 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
+{"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,0 +1,1 @@
+{"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,3 +1,5 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":7}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":16}
+{"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}
+{"pass":4,"status":"complete","artifact":"docs/c4-architecture.mermaid.md","seq_max":26}

--- a/docs/c4-pass1-runtime.json
+++ b/docs/c4-pass1-runtime.json
@@ -1,0 +1,28 @@
+{
+  "pass": 1,
+  "actors": [
+    {"id": "actor:developer", "label": "Developer", "evidence": ["human operator implied by git workflow"]}
+  ],
+  "externals": [
+    {
+      "id": "ext:github_hosting",
+      "label": "GitHub",
+      "evidence": [".git/config remote origin url https://github.com/Decreen/decreen-connectors"]
+    }
+  ],
+  "deployables": [],
+  "excluded": [
+    {
+      "kind": "deployable",
+      "reason": "No application entrypoints, manifests, Dockerfiles, or CI workflow files in tree"
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:dev_git_remote",
+      "from": "actor:developer",
+      "to": "ext:github_hosting",
+      "label": "git clone/fetch/push"
+    }
+  ]
+}

--- a/docs/c4-pass2-l2.json
+++ b/docs/c4-pass2-l2.json
@@ -1,0 +1,46 @@
+{
+  "pass": 2,
+  "system": {
+    "id": "sys:decreen_connectors",
+    "label": "Decreen connectors (repository)",
+    "evidence": [".git/config remote origin url path Decreen/decreen-connectors"]
+  },
+  "containers": [
+    {
+      "id": "container:tracked_sources",
+      "label": "Tracked source files",
+      "evidence": ["LICENSE", ".gitignore"]
+    },
+    {
+      "id": "container:scm_integration",
+      "label": "Git / SCM integration",
+      "evidence": [".git/config core.hooksPath", ".git/config remote origin"]
+    }
+  ],
+  "excluded": [
+    {
+      "kind": "container",
+      "id": "candidate:readme_docs",
+      "reason": "Documentation paths excluded as architecture evidence"
+    },
+    {
+      "kind": "container",
+      "id": "candidate:runtime_services",
+      "reason": "No runtime orchestration or app manifests in tree"
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:dev_maintains_repo",
+      "from": "actor:developer",
+      "to": "sys:decreen_connectors",
+      "label": "maintains repository"
+    },
+    {
+      "id": "edge:github_hosts_repo",
+      "from": "ext:github_hosting",
+      "to": "sys:decreen_connectors",
+      "label": "hosts remote repository"
+    }
+  ]
+}

--- a/docs/c4-pass3-l3.json
+++ b/docs/c4-pass3-l3.json
@@ -1,0 +1,51 @@
+{
+  "pass": 3,
+  "selected_containers": [
+    {
+      "id": "container:tracked_sources",
+      "aspects_satisfied": ["state", "routing", "subsystems"],
+      "components": [
+        {
+          "id": "component:tracked_license_and_ignore",
+          "kind": "storage",
+          "aspects": ["state", "subsystems"]
+        },
+        {
+          "id": "component:repository_tree_boundary",
+          "kind": "boundary",
+          "aspects": ["routing", "state"]
+        }
+      ]
+    },
+    {
+      "id": "container:scm_integration",
+      "aspects_satisfied": ["API", "routing", "processing", "subsystems"],
+      "components": [
+        {
+          "id": "component:git_origin_remote",
+          "kind": "integration",
+          "aspects": ["routing", "API"]
+        },
+        {
+          "id": "component:git_hooks_path",
+          "kind": "scheduler",
+          "aspects": ["processing", "subsystems"]
+        }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge:hooks_invoke_remote_ops",
+      "from": "component:git_hooks_path",
+      "to": "component:git_origin_remote",
+      "label": "precedes / accompanies git operations"
+    },
+    {
+      "id": "edge:scm_views_tracked_tree",
+      "from": "component:git_origin_remote",
+      "to": "component:repository_tree_boundary",
+      "label": "versioned tree"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change introduces a C4 model driven by an append-only event stream in `docs/c4-events.ndjson`, with pass artifacts (`docs/c4-pass1-runtime.json` through `docs/c4-pass3-l3.json`), a continuously updated live Mermaid preview (`docs/c4-live.mermaid.md`), and the final architecture document (`docs/c4-architecture.mermaid.md`) including L1–L3 diagrams and the required containment map.

Evidence is limited to what exists in the repository tree (notably `.git/config` for GitHub remote and `LICENSE`/`.gitignore` as tracked files); no application runtime or deployables were found in the checked-in sources.

**Update:** `docs/c4-pass3-l3.json` was added in a follow-up commit so the Pass 3 artifact is tracked on the branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15147962-73ea-4104-8b7e-6a44e937f4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15147962-73ea-4104-8b7e-6a44e937f4e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

