### PR TITLE
C4 architecture from append-only event stream

### DIFF
--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,0 +1,3 @@
+# C4 Architecture
+
+_Not finalized yet._

--- a/docs/c4-architecture.mermaid.md
+++ b/docs/c4-architecture.mermaid.md
@@ -1,3 +1,67 @@
 # C4 Architecture
 
-_Not finalized yet._
+Final projection from `docs/c4-events.ndjson` (replayed through Pass 4 freeze).
+
+## L1 — System context
+
+```mermaid
+flowchart TD
+  actor_developer["Developer"]
+  ext_github["GitHub"]
+  sys_decreen_connectors["Decreen connectors (VCS-hosted repository)"]
+  actor_developer -->|"push / pull"| ext_github
+  ext_github -->|"hosts"| sys_decreen_connectors
+  actor_developer -->|"clone / contribute"| sys_decreen_connectors
+```
+
+## L2 — Container diagram
+
+```mermaid
+flowchart TB
+  actor_developer["Developer"]
+  ext_github["GitHub"]
+  subgraph sys_decreen_connectors["Decreen connectors (VCS-hosted repository)"]
+    container_repository_tree["Repository tree<br/><small>filesystem / VCS working tree</small>"]
+  end
+  actor_developer -->|"push / pull"| ext_github
+  ext_github -->|"hosts"| sys_decreen_connectors
+  actor_developer -->|"clone / contribute"| sys_decreen_connectors
+```
+
+## L3 — Repository tree
+
+```mermaid
+flowchart TB
+  subgraph container_repository_tree["Repository tree"]
+    direction TB
+    %% SCOPE: urn:c4:container:repository_tree
+    component_boundary_gitignore[".gitignore rules"]
+    %% KIND: boundary
+    component_storage_license["LICENSE text"]
+    %% KIND: storage
+    component_integration_gitignore["VCS ignore integration"]
+    %% KIND: integration
+    component_boundary_gitignore -->|"co-located artifacts"| component_storage_license
+  end
+```
+
+## Containment Map
+
+```json
+{
+  "parentToChildren": {
+    "sys_decreen_connectors": ["container_repository_tree"],
+    "container_repository_tree": [
+      "component_boundary_gitignore",
+      "component_storage_license",
+      "component_integration_gitignore"
+    ]
+  },
+  "childToParent": {
+    "container_repository_tree": "sys_decreen_connectors",
+    "component_boundary_gitignore": "container_repository_tree",
+    "component_storage_license": "container_repository_tree",
+    "component_integration_gitignore": "container_repository_tree"
+  }
+}
+```

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -22,3 +22,5 @@
 {"seq":22,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3_api_surface","reason":"No HTTP or RPC server code in repository tree"}}
 {"seq":23,"pass":3,"event":"group_nodes","payload":{"id":"group:pass3_l3","label":"Pass 3 components","members":["component:boundary_gitignore","component:storage_license","component:integration_gitignore"]}}
 {"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3}}
+{"seq":25,"pass":4,"event":"refine_label","payload":{"id":"sys:decreen_connectors","label":"Decreen connectors (VCS-hosted repository)"}}
+{"seq":26,"pass":4,"event":"freeze_pass","payload":{"pass":4}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,0 +1,1 @@
+{"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -6,3 +6,11 @@
 {"seq":6,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:packaged_service","reason":"No application manifests (e.g. pyproject.toml, package.json) or Dockerfiles in repository tree"}}
 {"seq":7,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:orchestrated_runtime","reason":"No CI workflows, container orchestration, or runtime IaC files in repository tree"}}
 {"seq":8,"pass":1,"event":"freeze_pass","payload":{"pass":1}}
+{"seq":9,"pass":2,"event":"set_system_boundary","payload":{"id":"sys:decreen_connectors","label":"Decreen connectors repository"}}
+{"seq":10,"pass":2,"event":"add_container","payload":{"id":"container:repository_tree","label":"Repository tree","technology":"filesystem / VCS working tree"}}
+{"seq":11,"pass":2,"event":"add_edge","payload":{"id":"edge:github_hosts_system","from":"ext:github","to":"sys:decreen_connectors","label":"hosts"}}
+{"seq":12,"pass":2,"event":"add_edge","payload":{"id":"edge:dev_contributes","from":"actor:developer","to":"sys:decreen_connectors","label":"clone / contribute"}}
+{"seq":13,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_ci_pipeline","reason":"No .github/workflows or other CI config files in repository tree"}}
+{"seq":14,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_application_runtime","reason":"No executable application source or runtime entrypoints in repository tree"}}
+{"seq":15,"pass":2,"event":"group_nodes","payload":{"id":"group:pass2_l2","label":"Pass 2 containers","members":["sys:decreen_connectors","container:repository_tree"]}}
+{"seq":16,"pass":2,"event":"freeze_pass","payload":{"pass":2}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -14,3 +14,11 @@
 {"seq":14,"pass":2,"event":"exclude_candidate","payload":{"id":"candidate:container_application_runtime","reason":"No executable application source or runtime entrypoints in repository tree"}}
 {"seq":15,"pass":2,"event":"group_nodes","payload":{"id":"group:pass2_l2","label":"Pass 2 containers","members":["sys:decreen_connectors","container:repository_tree"]}}
 {"seq":16,"pass":2,"event":"freeze_pass","payload":{"pass":2}}
+{"seq":17,"pass":3,"event":"add_component","payload":{"id":"component:boundary_gitignore","label":".gitignore rules","container":"container:repository_tree","kind":"boundary"}}
+{"seq":18,"pass":3,"event":"add_component","payload":{"id":"component:storage_license","label":"LICENSE text","container":"container:repository_tree","kind":"storage"}}
+{"seq":19,"pass":3,"event":"add_component","payload":{"id":"component:integration_gitignore","label":"VCS ignore integration","container":"container:repository_tree","kind":"integration"}}
+{"seq":20,"pass":3,"event":"add_edge","payload":{"id":"edge:ignore_to_license","from":"component:boundary_gitignore","to":"component:storage_license","label":"co-located artifacts"}}
+{"seq":21,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3_second_container","reason":"Only one deployable container (repository tree) identified in Pass 2"}}
+{"seq":22,"pass":3,"event":"exclude_candidate","payload":{"id":"candidate:l3_api_surface","reason":"No HTTP or RPC server code in repository tree"}}
+{"seq":23,"pass":3,"event":"group_nodes","payload":{"id":"group:pass3_l3","label":"Pass 3 components","members":["component:boundary_gitignore","component:storage_license","component:integration_gitignore"]}}
+{"seq":24,"pass":3,"event":"freeze_pass","payload":{"pass":3}}

--- a/docs/c4-events.ndjson
+++ b/docs/c4-events.ndjson
@@ -1,1 +1,8 @@
 {"seq":1,"pass":0,"event":"group_nodes","payload":{"id":"group:bootstrap","label":"C4 generation bootstrap","members":[]}}
+{"seq":2,"pass":1,"event":"add_actor","payload":{"id":"actor:developer","label":"Developer"}}
+{"seq":3,"pass":1,"event":"add_external","payload":{"id":"ext:github","label":"GitHub"}}
+{"seq":4,"pass":1,"event":"add_edge","payload":{"id":"edge:dev_vcs","from":"actor:developer","to":"ext:github","label":"push / pull"}}
+{"seq":5,"pass":1,"event":"group_nodes","payload":{"id":"group:pass1_runtime","label":"Pass 1 runtime inventory","members":["actor:developer","ext:github"]}}
+{"seq":6,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:packaged_service","reason":"No application manifests (e.g. pyproject.toml, package.json) or Dockerfiles in repository tree"}}
+{"seq":7,"pass":1,"event":"exclude_candidate","payload":{"id":"candidate:orchestrated_runtime","reason":"No CI workflows, container orchestration, or runtime IaC files in repository tree"}}
+{"seq":8,"pass":1,"event":"freeze_pass","payload":{"pass":1}}

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -8,7 +8,13 @@ flowchart TB
     actor_developer -->|"push / pull"| ext_github
   end
   subgraph sys_decreen_connectors["Decreen connectors repository"]
-    container_repository_tree["Repository tree<br/><small>filesystem / VCS working tree</small>"]
+    subgraph container_repository_tree["Repository tree"]
+      direction TB
+      component_boundary_gitignore[".gitignore rules"]
+      component_storage_license["LICENSE text"]
+      component_integration_gitignore["VCS ignore integration"]
+      component_boundary_gitignore -->|"co-located artifacts"| component_storage_license
+    end
   end
   ext_github -->|"hosts"| sys_decreen_connectors
   actor_developer -->|"clone / contribute"| sys_decreen_connectors

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -5,9 +5,8 @@ flowchart TB
   subgraph L1["Context"]
     actor_developer["Developer"]
     ext_github["GitHub"]
-    actor_developer -->|"push / pull"| ext_github
   end
-  subgraph sys_decreen_connectors["Decreen connectors repository"]
+  subgraph sys_decreen_connectors["Decreen connectors (VCS-hosted repository)"]
     subgraph container_repository_tree["Repository tree"]
       direction TB
       component_boundary_gitignore[".gitignore rules"]
@@ -16,6 +15,7 @@ flowchart TB
       component_boundary_gitignore -->|"co-located artifacts"| component_storage_license
     end
   end
+  actor_developer -->|"push / pull"| ext_github
   ext_github -->|"hosts"| sys_decreen_connectors
   actor_developer -->|"clone / contribute"| sys_decreen_connectors
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,10 +1,15 @@
 # Live C4 Preview
 
 ```mermaid
-flowchart TD
-  subgraph L1["System context (Pass 1)"]
+flowchart TB
+  subgraph L1["Context"]
     actor_developer["Developer"]
     ext_github["GitHub"]
     actor_developer -->|"push / pull"| ext_github
   end
+  subgraph sys_decreen_connectors["Decreen connectors repository"]
+    container_repository_tree["Repository tree<br/><small>filesystem / VCS working tree</small>"]
+  end
+  ext_github -->|"hosts"| sys_decreen_connectors
+  actor_developer -->|"clone / contribute"| sys_decreen_connectors
 ```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -1,0 +1,6 @@
+# Live C4 Preview
+
+```mermaid
+flowchart TD
+  boot["C4 generation started"]
+```

--- a/docs/c4-live.mermaid.md
+++ b/docs/c4-live.mermaid.md
@@ -2,5 +2,9 @@
 
 ```mermaid
 flowchart TD
-  boot["C4 generation started"]
+  subgraph L1["System context (Pass 1)"]
+    actor_developer["Developer"]
+    ext_github["GitHub"]
+    actor_developer -->|"push / pull"| ext_github
+  end
 ```

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,2 +1,3 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":8}
+{"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":16}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,3 +1,4 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":8}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":16}
+{"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -2,3 +2,4 @@
 {"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":8}
 {"pass":2,"status":"complete","artifact":"docs/c4-pass2-l2.json","seq_max":16}
 {"pass":3,"status":"complete","artifact":"docs/c4-pass3-l3.json","seq_max":24}
+{"pass":4,"status":"complete","artifact":"docs/c4-architecture.mermaid.md","seq_max":26}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,1 +1,2 @@
 {"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}
+{"pass":1,"status":"complete","artifact":"docs/c4-pass1-runtime.json","seq_max":8}

--- a/docs/c4-partial.ndjson
+++ b/docs/c4-partial.ndjson
@@ -1,0 +1,1 @@
+{"pass":0,"status":"bootstrapped","artifact":"docs/c4-live.mermaid.md","seq_max":1}

--- a/docs/c4-pass1-runtime.json
+++ b/docs/c4-pass1-runtime.json
@@ -1,0 +1,20 @@
+{
+  "pass": 1,
+  "actors": [
+    { "id": "actor:developer", "label": "Developer" }
+  ],
+  "externals": [
+    { "id": "ext:github", "label": "GitHub" }
+  ],
+  "deployables": [],
+  "excluded": [
+    {
+      "id": "candidate:packaged_service",
+      "reason": "No application manifests (e.g. pyproject.toml, package.json) or Dockerfiles in repository tree"
+    },
+    {
+      "id": "candidate:orchestrated_runtime",
+      "reason": "No CI workflows, container orchestration, or runtime IaC files in repository tree"
+    }
+  ]
+}

--- a/docs/c4-pass2-l2.json
+++ b/docs/c4-pass2-l2.json
@@ -1,0 +1,24 @@
+{
+  "pass": 2,
+  "system_boundary": {
+    "id": "sys:decreen_connectors",
+    "label": "Decreen connectors repository"
+  },
+  "containers": [
+    {
+      "id": "container:repository_tree",
+      "label": "Repository tree",
+      "technology": "filesystem / VCS working tree"
+    }
+  ],
+  "excluded": [
+    {
+      "id": "candidate:container_ci_pipeline",
+      "reason": "No .github/workflows or other CI config files in repository tree"
+    },
+    {
+      "id": "candidate:container_application_runtime",
+      "reason": "No executable application source or runtime entrypoints in repository tree"
+    }
+  ]
+}

--- a/docs/c4-pass3-l3.json
+++ b/docs/c4-pass3-l3.json
@@ -1,0 +1,35 @@
+{
+  "pass": 3,
+  "selected_containers": [
+    {
+      "id": "container:repository_tree",
+      "components": [
+        {
+          "id": "component:boundary_gitignore",
+          "label": ".gitignore rules",
+          "kind": "boundary"
+        },
+        {
+          "id": "component:storage_license",
+          "label": "LICENSE text",
+          "kind": "storage"
+        },
+        {
+          "id": "component:integration_gitignore",
+          "label": "VCS ignore integration",
+          "kind": "integration"
+        }
+      ]
+    }
+  ],
+  "excluded": [
+    {
+      "id": "candidate:l3_second_container",
+      "reason": "Only one deployable container (repository tree) identified in Pass 2"
+    },
+    {
+      "id": "candidate:l3_api_surface",
+      "reason": "No HTTP or RPC server code in repository tree"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change introduces a C4-style architecture model driven by an append-only event stream in `docs/c4-events.ndjson`. Diagrams and pass artifacts are projections of that stream.

## Artifacts

- `docs/c4-events.ndjson` — source of truth (events through Pass 4 freeze)
- `docs/c4-live.mermaid.md` — live Mermaid projection
- `docs/c4-architecture.mermaid.md` — final L1/L2/L3 diagrams and containment map
- `docs/c4-pass1-runtime.json`, `docs/c4-pass2-l2.json`, `docs/c4-pass3-l3.json` — pass snapshots
- `docs/c4-partial.ndjson` — progress checkpoints

## Evidence scope

Modeling follows **code-only** evidence: the repository tree currently contains only `.gitignore`, `LICENSE`, and `README.md` (README excluded per policy). The system is modeled as a VCS-hosted repository with a single container representing the working tree and components for observable artifacts.

## Commits

Five checkpoints: bootstrap, Pass 1–4, each pushed to `cursor/c4-architecture-event-stream-f872`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89f8e4e3-2232-4607-8ad2-472bd6bb6767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89f8e4e3-2232-4607-8ad2-472bd6bb6767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

